### PR TITLE
Repeat all pending events, to prevent axis sticking

### DIFF
--- a/virtjs.c
+++ b/virtjs.c
@@ -115,8 +115,9 @@ int main(int argc, char *argv[])
 		if (fds[0].revents & POLLIN) {
 			struct input_event ev;
 			rc = libevdev_next_event(real, LIBEVDEV_READ_FLAG_BLOCKING, &ev);
-			if (rc == 0) {
+			while (rc == 0) {
 				write(uifd, &ev, sizeof(ev));
+				rc = libevdev_next_event(real, LIBEVDEV_READ_FLAG_BLOCKING, &ev);
 			}
 		}
 		if (fds[1].revents & (POLLERR | POLLHUP)) {


### PR DESCRIPTION
I found this issue when testing some code derived from yours. It would be really easy to get the axes on the virtual device to stick by rapidly releasing the real pedals. By looping until all pending events are read, the issue goes away.